### PR TITLE
Migrate to Gemini API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 SEARCH_API_KEY=your_google_custom_search_key
 SEARCH_ENGINE_ID=your_search_engine_id
-OPENAI_API_KEY=your_openai_api_key
+GEMINI_API_KEY=your_google_ai_studio_key
 LINKEDIN_KEYWORDS=Artificial Intelligence, Generative AI, LLM, Machine Learning

--- a/README.md
+++ b/README.md
@@ -51,23 +51,20 @@ To use the Google Custom Search API, you need a Programmable Search Engine that 
 7.  Copy the **search engine ID** (it looks like `cx=...` or a long string) and paste it into your `.env` as `SEARCH_ENGINE_ID`.
 8.  *Note: Ensure your Google Cloud Project associated with the API Key has the "Custom Search API" enabled.*
 
-### Detailed Setup: Getting the OpenAI API Key
-To utilize the summarization features, you need an OpenAI API Key.
+8.  *Note: Ensure your Google Cloud Project associated with the API Key has the "Custom Search API" enabled.*
 
-1.  Sign up or log in to the [OpenAI Platform](https://platform.openai.com/).
-2.  Navigate to the **Dashboard** -> **API keys**.
-3.  Click **Create new secret key**.
-4.  Name the key (e.g., "AI Newsletter Tool").
-5.  Copy the key (it starts with `sk-...`) and paste it into your `.env` as `OPENAI_API_KEY`.
-6.  *Note: You must have credits or a payment method added to your OpenAI account for the API to work.*
+### Detailed Setup: Getting the Gemini API Key
+To utilize the summarization features, you need a Google Gemini API Key.
+
+1.  Go to [Google AI Studio](https://aistudio.google.com/app/apikey).
+2.  Click **Create API Key**.
+3.  Copy the key and paste it into your `.env` as `GEMINI_API_KEY`.
+4.  *Note: This API is currently free (within rate limits) for many regions.*
 
 ## Troubleshooting
 
-### OpenAI 429 (Insufficient Quota)
-If you see a `RateLimitError: 429` with `insufficient_quota`:
-*   **Cause**: Your OpenAI API account has run out of credits.
-*   **Fix**: Go to [OpenAI Billing](https://platform.openai.com/account/billing/overview) and add a credit balance (e.g., $5).
-*   **Important**: A "ChatGPT Plus" subscription ($20/mo) does **not** verify you for API usage. They are separate billing systems.
+### OpenAI 429
+*Note: OpenAI integration has been replaced by Gemini. If you see OpenAI errors, ensure you have pulled the latest code and updated your `.env`.*
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@google/generative-ai": "^0.24.1",
         "@types/cheerio": "^0.22.35",
         "@types/node": "^24.10.2",
         "axios": "^1.13.2",
         "cheerio": "^1.1.2",
         "date-fns": "^4.1.0",
         "dotenv": "^17.2.3",
-        "openai": "^6.10.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
       },
@@ -577,6 +577,15 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -4157,27 +4166,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/openai": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.10.0.tgz",
-      "integrity": "sha512-ITxOGo7rO3XRMiKA5l7tQ43iNNu+iXGFAcf2t+aWVzzqRaS0i7m1K2BhxNdaveB+5eENhO0VY1FkiZzhBk4v3A==",
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
       }
     },
     "node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "@types/cheerio": "^0.22.35",
     "@types/node": "^24.10.2",
     "axios": "^1.13.2",
     "cheerio": "^1.1.2",
     "date-fns": "^4.1.0",
     "dotenv": "^17.2.3",
-    "openai": "^6.10.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,6 @@ dotenv.config();
 export const config = {
     SEARCH_API_KEY: process.env.SEARCH_API_KEY || '',
     SEARCH_ENGINE_ID: process.env.SEARCH_ENGINE_ID || '', // for Google Custom Search
-    OPENAI_API_KEY: process.env.OPENAI_API_KEY || '',
+    GEMINI_API_KEY: process.env.GEMINI_API_KEY || '',
     LINKEDIN_KEYWORDS: (process.env.LINKEDIN_KEYWORDS || 'Artificial Intelligence, LLM, Generative AI').split(',').map(k => k.trim()),
 };

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -1,43 +1,35 @@
-import OpenAI from 'openai';
+import { GoogleGenerativeAI } from '@google/generative-ai';
 import { config } from './config';
 import { LinkedInPost } from './collector';
 
 export class Processor {
-    private openai: OpenAI | null = null;
+    private genAI: GoogleGenerativeAI | null = null;
 
     constructor() {
-        if (config.OPENAI_API_KEY) {
-            this.openai = new OpenAI({ apiKey: config.OPENAI_API_KEY });
+        if (config.GEMINI_API_KEY) {
+            this.genAI = new GoogleGenerativeAI(config.GEMINI_API_KEY);
         }
     }
 
     async summarize(posts: LinkedInPost[]): Promise<string> {
         if (posts.length === 0) return "No posts found to summarize.";
 
-        if (!this.openai) {
-            console.warn('⚠️ No OPENAI_API_KEY found. Returning static summary.');
-            return "## AI Update (Mock)\n\nToday saw discussions about **Generative AI** and **LLM Benchmarks**. (Configure OpenAI Key for real summary).";
+        if (!this.genAI) {
+            console.warn('⚠️ No GEMINI_API_KEY found. Returning static summary.');
+            return "## AI Update (Mock)\n\nToday saw discussions about **Generative AI** and **LLM Benchmarks**. (Configure Gemini Key for real summary).";
         }
 
         const postsText = posts.map(p => `- Title: ${p.title}\n  Snippet: ${p.snippet}\n  Link: ${p.link}`).join('\n\n');
 
         try {
-            const completion = await this.openai.chat.completions.create({
-                messages: [
-                    { role: "system", content: "You are an expert tech newsletter writer. Summarize the following LinkedIn posts into a concise, engaging daily AI update. Focus on the key trends and interesting points. Output in Markdown." },
-                    { role: "user", content: `Here are the top LinkedIn posts from the last 24 hours:\n\n${postsText}` }
-                ],
-                model: "gpt-4o",
-            });
+            const model = this.genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
 
-            return completion.choices[0].message.content || "Failed to generate summary.";
+            const prompt = `You are an expert tech newsletter writer. Summarize the following LinkedIn posts into a concise, engaging daily AI update. Focus on the key trends and interesting points. Output in Markdown.\n\nHere are the top LinkedIn posts from the last 24 hours:\n${postsText}`;
+
+            const result = await model.generateContent(prompt);
+            const response = await result.response;
+            return response.text();
         } catch (error: any) {
-            if (error?.status === 429 || error?.code === 'insufficient_quota') {
-                console.error('\n❌ OpenAI Error: You have exceeded your quota or have no credits.');
-                console.error('👉 Fix: Go to https://platform.openai.com/account/billing/overview and add credits to your account.');
-                console.error('   Note: ChatGPT Plus subscriptions do NOT cover API usage.\n');
-                return "Summary unavailable: OpenAI Quota Exceeded (Check Billing).";
-            }
             console.error('Error generating summary:', error);
             return "Error generating summary. Check API keys.";
         }

--- a/tests/processor.test.ts
+++ b/tests/processor.test.ts
@@ -1,50 +1,54 @@
 import { Processor } from '../src/processor';
-import OpenAI from 'openai';
 import { config } from '../src/config';
 
-// Mock OpenAI
-const mockCreate = jest.fn();
-jest.mock('openai', () => {
-    return jest.fn().mockImplementation(() => {
-        return {
-            chat: {
-                completions: {
-                    create: mockCreate,
-                },
-            },
-        };
-    });
+// Mock @google/generative-ai
+const mockGenerateContent = jest.fn();
+const mockGetGenerativeModel = jest.fn().mockReturnValue({
+    generateContent: mockGenerateContent,
+});
+
+jest.mock('@google/generative-ai', () => {
+    return {
+        GoogleGenerativeAI: jest.fn().mockImplementation(() => {
+            return {
+                getGenerativeModel: mockGetGenerativeModel,
+            };
+        }),
+    };
 });
 
 describe('Processor', () => {
     beforeEach(() => {
         jest.clearAllMocks();
-        config.OPENAI_API_KEY = 'test-key';
+        config.GEMINI_API_KEY = 'test-key';
     });
 
     it('should return static summary if no API key', async () => {
-        config.OPENAI_API_KEY = '';
+        config.GEMINI_API_KEY = '';
         const processor = new Processor();
         const summary = await processor.summarize([{ title: 't', link: 'l', snippet: 's', source: 'src' }]);
 
         expect(summary).toContain('(Mock)');
-        expect(mockCreate).not.toHaveBeenCalled();
+        expect(mockGetGenerativeModel).not.toHaveBeenCalled();
     });
 
-    it('should call OpenAI and return summary', async () => {
-        mockCreate.mockResolvedValue({
-            choices: [{ message: { content: 'Generated Summary' } }],
+    it('should call Gemini and return summary', async () => {
+        mockGenerateContent.mockResolvedValue({
+            response: {
+                text: () => 'Gemini Summary',
+            },
         });
 
         const processor = new Processor();
         const summary = await processor.summarize([{ title: 't', link: 'l', snippet: 's', source: 'src' }]);
 
-        expect(summary).toBe('Generated Summary');
-        expect(mockCreate).toHaveBeenCalled();
+        expect(summary).toBe('Gemini Summary');
+        expect(mockGetGenerativeModel).toHaveBeenCalledWith({ model: 'gemini-1.5-flash' });
+        expect(mockGenerateContent).toHaveBeenCalled();
     });
 
-    it('should handle OpenAI errors', async () => {
-        mockCreate.mockRejectedValue(new Error('OpenAI Error'));
+    it('should handle Gemini errors', async () => {
+        mockGenerateContent.mockRejectedValue(new Error('Gemini Error'));
 
         const processor = new Processor();
         const summary = await processor.summarize([{ title: 't', link: 'l', snippet: 's', source: 'src' }]);


### PR DESCRIPTION
Replaces OpenAI with Google Gemini API for summarization.

**Changes:**
- Swapped `openai` for `@google/generative-ai`.
- Updated `.env.example` to use `GEMINI_API_KEY`.
- Updated `Processor` to use `gemini-1.5-flash`.
- Updated Tests and README.

Closes #1