### PR TITLE
Fix: Ensure Correct Gemini Model Version

### DIFF
--- a/src/processor.ts
+++ b/src/processor.ts
@@ -22,7 +22,7 @@ export class Processor {
         const postsText = posts.map(p => `- Title: ${p.title}\n  Snippet: ${p.snippet}\n  Link: ${p.link}`).join('\n\n');
 
         try {
-            const model = this.genAI.getGenerativeModel({ model: "gemini-1.5-flash-001" });
+            const model = this.genAI.getGenerativeModel({ model: "gemini-3-pro-preview" });
 
             const prompt = `You are an expert tech newsletter writer. Summarize the following LinkedIn posts into a concise, engaging daily AI update. Focus on the key trends and interesting points. Output in Markdown.\n\nHere are the top LinkedIn posts from the last 24 hours:\n${postsText}`;
 

--- a/tests/processor.test.ts
+++ b/tests/processor.test.ts
@@ -43,7 +43,7 @@ describe('Processor', () => {
         const summary = await processor.summarize([{ title: 't', link: 'l', snippet: 's', source: 'src' }]);
 
         expect(summary).toBe('Gemini Summary');
-        expect(mockGetGenerativeModel).toHaveBeenCalledWith({ model: 'gemini-1.5-flash-001' });
+        expect(mockGetGenerativeModel).toHaveBeenCalledWith({ model: 'gemini-3-pro-preview' });
         expect(mockGenerateContent).toHaveBeenCalled();
     });
 


### PR DESCRIPTION
Resolves 404 Error.
Ensures we are strictly using `gemini-3-pro-preview` which is available in the user's project, preventing 404 errors seen with flash/legacy models.